### PR TITLE
Update benchmarks

### DIFF
--- a/bench/concurrent_deps.py
+++ b/bench/concurrent_deps.py
@@ -2,8 +2,9 @@ import asyncio
 
 from typing import Annotated
 
-from di import Container, Dependant, AsyncExecutor
-
+from di.dependant import Dependant
+from di.executors import ConcurrentAsyncExecutor
+from di.container import Container
 from incant import Incanter
 
 
@@ -42,7 +43,7 @@ def di_func(
 
 
 container = Container()
-executor = AsyncExecutor()
+executor = ConcurrentAsyncExecutor()
 solved = container.solve(Dependant(di_func), scopes=[None])
 
 

--- a/bench/concurrent_deps.py
+++ b/bench/concurrent_deps.py
@@ -2,7 +2,7 @@ import asyncio
 
 from typing import Annotated
 
-from di import Container, Dependant
+from di import Container, Dependant, AsyncExecutor
 
 from incant import Incanter
 
@@ -42,8 +42,14 @@ def di_func(
 
 
 container = Container()
-solved = container.solve(Dependant(di_func))
+executor = AsyncExecutor()
+solved = container.solve(Dependant(di_func), scopes=[None])
+
+
+async def di_execute():
+    async with container.enter_scope(None) as state:
+        await container.execute_async(solved, state=state, executor=executor)
 
 
 def di_call_func():
-    asyncio.run(container.execute_async(solved))
+    asyncio.run(di_execute())

--- a/bench/concurrent_nested_deps.py
+++ b/bench/concurrent_nested_deps.py
@@ -2,8 +2,9 @@ import asyncio
 
 from typing import Annotated
 
-from di import ConcurrentAsyncExecutor, Container, Dependant
-
+from di.dependant import Dependant
+from di.executors import ConcurrentAsyncExecutor
+from di.container import Container, bind_by_type
 from incant import Incanter
 
 

--- a/bench/concurrent_nested_deps.py
+++ b/bench/concurrent_nested_deps.py
@@ -2,7 +2,7 @@ import asyncio
 
 from typing import Annotated
 
-from di import Container, Dependant
+from di import ConcurrentAsyncExecutor, Container, Dependant
 
 from incant import Incanter
 
@@ -64,8 +64,14 @@ def di_func(
 
 
 container = Container()
-solved = container.solve(Dependant(di_func))
+executor = ConcurrentAsyncExecutor()
+solved = container.solve(Dependant(di_func), scopes=[None])
+
+
+async def di_execute():
+    async with container.enter_scope(None) as state:
+        await container.execute_async(solved, state=state, executor=executor)
 
 
 def di_call_func():
-    asyncio.run(container.execute_async(solved))
+    asyncio.run(di_execute())

--- a/bench/single_dep.py
+++ b/bench/single_dep.py
@@ -5,8 +5,9 @@ A function with a single dependency; the dependency is satisfied by the containe
 """
 from dependency_injector import containers, providers
 from dependency_injector.wiring import Provide, inject
-from di import Container, Dependant, SyncExecutor
-from di.container import bind_by_type
+from di.dependant import Dependant
+from di.executors import SyncExecutor
+from di.container import Container, bind_by_type
 from wired import ServiceRegistry
 
 from incant import Incanter

--- a/bench/single_dep.py
+++ b/bench/single_dep.py
@@ -5,7 +5,8 @@ A function with a single dependency; the dependency is satisfied by the containe
 """
 from dependency_injector import containers, providers
 from dependency_injector.wiring import Provide, inject
-from di import Container, Dependant
+from di import Container, Dependant, SyncExecutor
+from di.container import bind_by_type
 from wired import ServiceRegistry
 
 from incant import Incanter
@@ -42,12 +43,14 @@ def wired_call_func():
 # di
 
 container = Container()
-container.bind(dep1, int)
-solved = container.solve(Dependant(func))
+executor = SyncExecutor()
+container.bind(bind_by_type(Dependant(dep1), int))
+solved = container.solve(Dependant(func), scopes=(None,))
 
 
 def di_call_func():
-    container.execute_sync(solved)
+    with container.enter_scope(None) as state:
+        container.execute_sync(solved, executor=executor, state=state)
 
 
 # Dependency-injector

--- a/bench/two_deps.py
+++ b/bench/two_deps.py
@@ -5,7 +5,9 @@ A function with two dependencies; the first depends on the other, and the other 
 """
 from dependency_injector import containers, providers
 from dependency_injector.wiring import Provide, inject
-from di import Container, Dependant, SyncExecutor
+from di.dependant import Dependant
+from di.executors import SyncExecutor
+from di.container import Container, bind_by_type
 from di.container import bind_by_type
 from wired import ServiceRegistry
 

--- a/bench/two_deps.py
+++ b/bench/two_deps.py
@@ -5,7 +5,8 @@ A function with two dependencies; the first depends on the other, and the other 
 """
 from dependency_injector import containers, providers
 from dependency_injector.wiring import Provide, inject
-from di import Container, Dependant
+from di import Container, Dependant, SyncExecutor
+from di.container import bind_by_type
 from wired import ServiceRegistry
 
 from incant import Incanter
@@ -55,13 +56,15 @@ def wired_call_func():
 # di
 
 container = Container()
-container.bind(dep1, int)
-container.bind(dep2, float)
-solved = container.solve(Dependant(func))
+executor = SyncExecutor()
+container.bind(bind_by_type(Dependant(dep1), int))
+container.bind(bind_by_type(Dependant(dep2), float))
+solved = container.solve(Dependant(func), scopes=(None,))
 
 
 def di_call_func():
-    container.execute_sync(solved, values={str: "1"})
+    with container.enter_scope(None) as state:
+        container.execute_sync(solved, values={str: "1"}, state=state, executor=executor)
 
 
 # Dependency-injector


### PR DESCRIPTION
This updates the benchmarks for di.

Here's the results I'm getting:

```
❯ make single_dep
Benchmarking incant: Mean +- std dev: 394 ns +- 27 ns
Benchmarking wired: Mean +- std dev: 50.6 us +- 1.9 us
Benchmarking di: Mean +- std dev: 6.26 us +- 0.18 us
Benchmarking dependency_injector: Mean +- std dev: 2.94 us +- 0.11 us

❯ make two_deps                               
Benchmarking incant: Mean +- std dev: 521 ns +- 31 ns
Benchmarking wired: Mean +- std dev: 91.7 us +- 4.1 us
Benchmarking di: Mean +- std dev: 7.03 us +- 0.50 us
Benchmarking dependency_injector: Mean +- std dev: 10.1 us +- 0.6 us

❯ LIBS="incant di" make concurrent_deps
Benchmarking incant: Mean +- std dev: 2.91 ms +- 0.04 ms
Benchmarking di: Mean +- std dev: 156 us +- 3 us

❯ LIBS="incant di" make concurrent_nested_deps
Benchmarking incant: Mean +- std dev: 105 ms +- 0 ms
Benchmarking di: Mean +- std dev: 159 us +- 6 us
```